### PR TITLE
🧠 018-main マージ時に GitHub Pages へデプロイ

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -1,0 +1,59 @@
+name: deploy-pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: webapp/frontend-react
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: yarn
+          cache-dependency-path: webapp/frontend-react/yarn.lock
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build for GitHub Pages
+        run: yarn run build --base "/${{ github.event.repository.name }}/"
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: webapp/frontend-react/dist
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+

--- a/docs/agent/018-main マージ時に GitHub Pages へデプロイ.md
+++ b/docs/agent/018-main マージ時に GitHub Pages へデプロイ.md
@@ -35,3 +35,12 @@ main マージ時に GitHub Pages へデプロイ
 ### 補足
 - この構成は「GitHub Pages をプロジェクトページとして運用 ( /<repo>/ )」前提。
 - カスタムドメイン運用時は `--base` 値を調整する。
+
+## レビュー
+
+### レビュワー指摘 (1 回目)
+1. `deploy` job で `environment: github-pages` と `url` を明示する設計を追記してください。
+2. リポジトリ設定で Pages の Source を `GitHub Actions` にする前提を、運用手順として追記してください。
+3. workflow 名とファイル名を固定し、どのファイルを追加するかを明記してください。
+
+判定: `Needs Fix`

--- a/docs/agent/018-main マージ時に GitHub Pages へデプロイ.md
+++ b/docs/agent/018-main マージ時に GitHub Pages へデプロイ.md
@@ -60,3 +60,17 @@ main マージ時に GitHub Pages へデプロイ
 - そのまま実装に移せる内容です。
 
 判定: `LGTM`
+
+## 実装結果
+- `.github/workflows/pages-deploy.yml` を追加しました。
+- `main` への push (マージ含む) と `workflow_dispatch` で Pages デプロイが走る構成です。
+- `build` job で `webapp/frontend-react` を `yarn run build --base \"/${{ github.event.repository.name }}/\"` でビルドします。
+- `deploy` job で `environment: github-pages` と `page_url` 連携を設定しました。
+
+## 運用メモ
+- リポジトリの `Settings > Pages` で Source を `GitHub Actions` に設定してください。
+- カスタムドメインで root 配信する場合は `--base` 値を変更してください。
+
+## オーナー向け要約
+- 要望どおり、`main` マージ時に GitHub Pages へ自動デプロイする仕組みを追加しました。
+- 手動実行 (`workflow_dispatch`) も可能なので、必要時に再デプロイできます。

--- a/docs/agent/018-main マージ時に GitHub Pages へデプロイ.md
+++ b/docs/agent/018-main マージ時に GitHub Pages へデプロイ.md
@@ -14,5 +14,24 @@ main マージ時に GitHub Pages へデプロイ
 - `webapp/frontend-react/vite.config.ts` (必要に応じて)
 
 ## 詳細設計
-(このセクションはプランナーが更新する)
+### デプロイ方式
+- GitHub Actions の専用 workflow (`pages-deploy.yml`) を追加する。
+- トリガーは `push` の `main` ブランチに限定する。
+- `workflow_dispatch` も有効化して、必要時に手動実行できるようにする。
 
+### build / deploy フロー
+1. `actions/checkout` でリポジトリ取得
+2. `actions/setup-node` で Node.js 22 をセットアップ
+3. `yarn install --frozen-lockfile` を `webapp/frontend-react` で実行
+4. `yarn run build --base \"/${{ github.event.repository.name }}/\"` を実行して Pages 用 build
+5. `actions/configure-pages` で Pages 設定
+6. `actions/upload-pages-artifact` で `webapp/frontend-react/dist` をアップロード
+7. `actions/deploy-pages` で公開
+
+### 権限 / 安全性
+- workflow の `permissions` は `contents: read`, `pages: write`, `id-token: write` に限定する。
+- `concurrency` を設定して、同時デプロイを 1 本に制御する。
+
+### 補足
+- この構成は「GitHub Pages をプロジェクトページとして運用 ( /<repo>/ )」前提。
+- カスタムドメイン運用時は `--base` 値を調整する。

--- a/docs/agent/018-main マージ時に GitHub Pages へデプロイ.md
+++ b/docs/agent/018-main マージ時に GitHub Pages へデプロイ.md
@@ -1,0 +1,18 @@
+main マージ時に GitHub Pages へデプロイ
+===
+
+## タスク概要
+- `main` へマージされたとき、フロントエンドを GitHub Pages へ自動デプロイする。
+
+## 今回の要望 (統合者まとめ)
+- `main` へ反映されたタイミングで GitHub Pages デプロイを実行したい。
+- 手動操作を減らし、デプロイを CI 化したい。
+
+## 変更対象
+- `docs/agent/018-main マージ時に GitHub Pages へデプロイ.md`
+- `.github/workflows/*`
+- `webapp/frontend-react/vite.config.ts` (必要に応じて)
+
+## 詳細設計
+(このセクションはプランナーが更新する)
+

--- a/docs/agent/018-main マージ時に GitHub Pages へデプロイ.md
+++ b/docs/agent/018-main マージ時に GitHub Pages へデプロイ.md
@@ -15,7 +15,7 @@ main マージ時に GitHub Pages へデプロイ
 
 ## 詳細設計
 ### デプロイ方式
-- GitHub Actions の専用 workflow (`pages-deploy.yml`) を追加する。
+- GitHub Actions の専用 workflow (`.github/workflows/pages-deploy.yml`) を追加する。
 - トリガーは `push` の `main` ブランチに限定する。
 - `workflow_dispatch` も有効化して、必要時に手動実行できるようにする。
 
@@ -28,6 +28,10 @@ main マージ時に GitHub Pages へデプロイ
 6. `actions/upload-pages-artifact` で `webapp/frontend-react/dist` をアップロード
 7. `actions/deploy-pages` で公開
 
+### deploy job の設定
+- `deploy` job には `environment: github-pages` を設定する。
+- `actions/deploy-pages` の出力 `page_url` を environment URL へ設定する。
+
 ### 権限 / 安全性
 - workflow の `permissions` は `contents: read`, `pages: write`, `id-token: write` に限定する。
 - `concurrency` を設定して、同時デプロイを 1 本に制御する。
@@ -35,6 +39,7 @@ main マージ時に GitHub Pages へデプロイ
 ### 補足
 - この構成は「GitHub Pages をプロジェクトページとして運用 ( /<repo>/ )」前提。
 - カスタムドメイン運用時は `--base` 値を調整する。
+- リポジトリの `Settings > Pages` で Source を `GitHub Actions` にしておく。
 
 ## レビュー
 
@@ -44,3 +49,14 @@ main マージ時に GitHub Pages へデプロイ
 3. workflow 名とファイル名を固定し、どのファイルを追加するかを明記してください。
 
 判定: `Needs Fix`
+
+### プランナー対応 (1 回目)
+1. `deploy` job の `environment` / `url` 設定方針を追記しました。
+2. `Settings > Pages` で `GitHub Actions` を選ぶ前提を追記しました。
+3. 追加対象ファイルを `.github/workflows/pages-deploy.yml` で明記しました。
+
+### レビュワー再レビュー (2 回目)
+- 指摘 1 から 3 の反映を確認しました。
+- そのまま実装に移せる内容です。
+
+判定: `LGTM`


### PR DESCRIPTION
## 要望
- `main` へ反映されたタイミングで GitHub Pages デプロイを実行したい。
- 手動操作を減らし、デプロイを CI 化したい。

## 変更内容
- `.github/workflows/pages-deploy.yml` を追加。
- `main` への `push` (マージ含む) と `workflow_dispatch` をトリガーに、GitHub Pages へ自動デプロイする workflow を実装。
- `webapp/frontend-react` を `yarn run build --base "/${{ github.event.repository.name }}/"` で Pages 向けにビルドし、`dist` を artifact としてアップロードして deploy する構成に整理。
- `deploy` job に `environment: github-pages` と `page_url` 連携を設定し、権限は `contents: read`, `pages: write`, `id-token: write` に限定。
