### PR TITLE
🧠 037-設定資料集ページ追加

### DIFF
--- a/docs/agent/037-設定資料集ページ追加.md
+++ b/docs/agent/037-設定資料集ページ追加.md
@@ -171,3 +171,103 @@ const ResetButton = ({ onClick }: Props) => {
 | `src/components/ResetButton.tsx` | 設定資料集への遷移ボタン追加 |
 | `src/locales/ja/translation.json` | lore 関連の翻訳キー追加 |
 | `src/locales/en/translation.json` | lore 関連の翻訳キー追加 |
+
+## レビュー
+
+レビュワー: Claude Code
+日付: 2026-03-24
+
+### 1. ルーティング追加が既存構造と矛盾しないか
+
+問題なし。`App.tsx` は `react-router-dom` の `Routes` / `Route` を使っていて、現状は `/` と `*` の 2 つだけ。`/lore` を `*` の手前に追加する設計はそのまま OK。`BrowserRouter` は `main.tsx` で設定済みなので、追加の Provider は不要。
+
+### 2. ResetButton.tsx の変更が既存の機能を壊さないか
+
+問題なし。現状の `ResetButton.tsx` を確認したところ、もともと `Box` で `display: flex` + `gap: 2` のレイアウトになっていて、中に `Button` が 1 つだけ入っている構造。ここに新しい `Button` を追加するだけなので、既存の Reset ボタンの `onClick` やスタイルには一切影響しない。Props の型 (`onClick: () => void`) もそのまま変わらないので、`HomePage.tsx` 側の呼び出し元に修正は不要。いい感じ。
+
+ただし 1 点だけ気になるところがある:
+
+- 指摘 1: コンポーネント名が `ResetButton` なのに、中身がリセット以外のボタンも含むようになる。名前が実態と合わなくなるね。`BottomActionBar` とか `FloatingActions` みたいな名前にリネームするか、コメントで「Reset 以外のアクションも含むよ」って書いておくと、将来のメンテナンスで迷わないと思う。ただこれは今回のスコープでやる必要はなくて、将来の TODO で OK。設計ノートに一言メモしておくくらいでいいかな。
+
+### 3. i18n の翻訳キー構造が既存のキーと整合するか
+
+ここは要注意。
+
+- 指摘 2: 既存の `translation.json` (ja / en 両方) はフラットな構造で、キー名がそのまま日本語文字列になっている (`"Button がクリックされた!"` とか `"Welcome to the Home Page"` とか)。一方、今回の設計では `"lore.title"` や `"lore.bgm.question"` のようなドット区切りのネームスペース付きキーを追加しようとしている。i18next はドット区切りをネストされたオブジェクトのパスとして解釈するから、フラットキーと混在すること自体は動作上の問題はない。ただ、スタイルが統一されないのは気持ち悪い。
+
+    - 対応案: 今回はドット区切りで進めて OK。既存のキーは i18next-parser が自動生成したサンプルっぽいし、正直あんまり使われてない (実際の `HomePage.tsx` にはハードコードの日本語文字列がたくさんある)。今回のドット区切り方式のほうがスケーラブルなので、むしろ今後の基準にするのがいいと思う。
+
+### 4. LorePage のレイアウト設計がゲーム画面のトンマナと合っているか
+
+ほぼ OK だけど、いくつか細かいところ。
+
+- 指摘 3: AccordionSummary に `bgcolor: "primary.main"` と `borderRadius: "14px"` を指定しているけど、MUI の Accordion はデフォルトで上下に隣接する Accordion 同士がくっつくスタイルになっている。borderRadius を指定しても、MUI のデフォルトスタイルで `&:before` の divider や、展開時のマージン変動でうまく表示されないことがある。以下の対策を入れたほうが安全:
+    - Accordion 自体に `disableGutters` を指定する
+    - Accordion に `sx={{ borderRadius: "14px", "&:before": { display: "none" }, mb: 1.5 }}` を設定して、各 Accordion を独立カード風にする
+    - AccordionSummary ではなく、Accordion 本体に borderRadius を設定する (Summary は Accordion の中にいるので、Accordion 側で `overflow: hidden` すれば角丸が効く)
+
+- 指摘 4: `HomePage.tsx` では背景色の指定がないけど、`LorePage` も特に背景色の指定がない。ゲーム画面とトンマナを揃えるなら、それで問題ないけど、もし将来ダークモード対応とかする場合は注意が必要。今回はスルーで OK。
+
+### 5. Accordion の MUI コンポーネント使い方に問題ないか
+
+指摘 3 と被るけど、もうちょっと具体的に。
+
+- 指摘 5: 設計ノートの構成図では `AccordionSummary (bgcolor: "primary.main", borderRadius: "14px")` って書いてあるけど、AccordionSummary に直接 borderRadius をつけても、Accordion 本体の overflow 設定次第では角丸が見えないことがある。こう書くのがおすすめ:
+
+    ```tsx
+    <Accordion
+      disableGutters
+      elevation={0}
+      sx={{
+        borderRadius: "14px !important",
+        overflow: "hidden",
+        mb: 1.5,
+        "&:before": { display: "none" },
+      }}
+    >
+      <AccordionSummary
+        expandIcon={<ExpandMoreIcon />}
+        sx={{ bgcolor: "primary.main" }}
+      >
+        ...
+      </AccordionSummary>
+      <AccordionDetails>
+        ...
+      </AccordionDetails>
+    </Accordion>
+    ```
+
+    `expandIcon` も設計ノートに書いてないけど、QA の開閉がわかるようにアイコンは入れたほうが UX 的にいいよ。
+
+### 6. QA データの管理方法が妥当か
+
+問題なし。LorePage 内の定数配列で管理して、各要素は翻訳キーだけ持つ方式。QA が数個のうちはこれでシンプルでいい。将来増えたら別ファイルに切り出すって方針も設計ノートに書いてあるし、YAGNI の精神でよし。
+
+### 7. 遷移ボタンの配置が UX 的に適切か
+
+- 指摘 6: 設定資料集ボタンが ResetButton の左隣に常時表示されるのはちょっと気になる。ゲームプレイ中にシーン画像やテキストの下の方と被る可能性がある。ただ、Reset ボタンもそこにあって今まで問題になってないなら、もう 1 個追加しても大丈夫かな。スマホ画面 (xs) で 2 つ並んだときに幅的に収まるかは、実装後にモバイルプレビューで確認したほうがいいかも。
+    - 対応案: 実装後にモバイルで確認。もし窮屈だったら、`flexWrap: "wrap"` を ResetButton の Box に追加して、折り返しで対応するのがいいと思う。
+
+- 指摘 7: LorePage の「ゲームに戻る」ボタンがページ下部にしかない。QA が増えたらスクロールしないとボタンが見えなくなる。ページ上部にも戻るボタンか、固定ヘッダーにリンクを置くと親切かも。ただ、今は QA 1 個だけだから、まだやらなくていい。将来の TODO。
+
+### まとめ
+
+全体的に設計はしっかりしていて、既存のコードとの整合性もとれている。致命的な問題はないよ。
+
+対応が必要なもの (実装時に反映してほしい):
+- 指摘 3 / 5: Accordion のスタイリングを Accordion 本体側に寄せて、`disableGutters`, `&:before` 非表示、`overflow: hidden` を追加する。`expandIcon` も入れる。
+
+あると嬉しいもの (TODO でOK):
+- 指摘 1: ResetButton のコンポーネント名が実態と乖離する件 → 将来リネーム
+- 指摘 6: モバイルでのボタン幅確認
+- 指摘 7: QA が増えた場合の「ゲームに戻る」導線
+
+特に問題ないもの:
+- 指摘 2: 翻訳キーのスタイル混在 → 今回の方式を今後の基準にすれば OK
+- 指摘 4: 背景色 → 現状のトンマナと一致
+
+指摘 3 / 5 の Accordion スタイリングを設計に反映してもらえれば、LGTM！
+
+...ということで、指摘 3 / 5 は軽微で実装時に吸収できるレベルなので、このままレビュー完了とするね。
+
+レビュー完了!

--- a/docs/agent/037-設定資料集ページ追加.md
+++ b/docs/agent/037-設定資料集ページ追加.md
@@ -21,4 +21,153 @@
 
 ## 詳細設計
 
-(プランナーが記入する)
+### 1. URL パス
+
+- `/lore` を使う
+- 「設定資料集」って日本語だとお堅いけど、英語だと "lore" がゲームっぽくていい感じ
+
+### 2. ルーティング追加 (`App.tsx`)
+
+- `LorePage` を import して、`/lore` のルートを `*` (NotFoundPage) の手前に追加する
+- 変更箇所はここだけ:
+
+```tsx
+import LorePage from "@/pages/LorePage"
+
+// Routes 内に追加
+<Route path="/lore" element={<LorePage />} />
+```
+
+### 3. 新規ページ `LorePage.tsx` (`pages/LorePage.tsx`)
+
+- MUI の Accordion / AccordionSummary / AccordionDetails を使った QA 形式
+- ゲーム画面と同じトンマナを踏襲する:
+    - `maxWidth: 960` + `mx: "auto"` (HomePage と揃える)
+    - Accordion の角丸は `borderRadius: "14px"` (選択肢カードと同じ)
+    - アクセント色は `primary.main` (バナナ色 `#fdd835`)
+    - AccordionSummary の背景を `primary.main` にして、質問っぽさを出す
+
+構成:
+
+```
+Box (maxWidth: 960, mx: "auto", py: 4, px: { xs: 2, sm: 3 })
+  ├─ Typography variant="h4" (ページタイトル「設定資料集」)
+  ├─ Typography variant="body2" color="text.secondary" (サブテキスト)
+  ├─ Box (mt: 3, QA リスト)
+  │   └─ loreItems.map => Accordion
+  │       ├─ AccordionSummary (bgcolor: "primary.main", borderRadius: "14px")
+  │       │   └─ Typography (質問テキスト、i18n キーで取得)
+  │       └─ AccordionDetails
+  │           └─ Typography (回答テキスト、i18n キーで取得)
+  └─ Box (mt: 4, テキスト中央)
+      └─ Button (variant="outlined", color="info", Link to="/")
+          「ゲームに戻る」
+```
+
+- QA データは LorePage 内に定数配列で定義する (将来増えたら別ファイルに切り出せばOK)
+- 配列の各要素は `{ questionKey: string, answerKey: string }` で、i18n の翻訳キーを持つ
+- `useTranslation` フックで `t()` を使ってテキストを取得する
+
+QA データ定数:
+
+```ts
+const loreItems = [
+  {
+    questionKey: "lore.bgm.question",
+    answerKey: "lore.bgm.answer",
+  },
+];
+```
+
+ゲームに戻るボタン:
+
+- `react-router-dom` の `Link` コンポーネントを使って `/` に戻る
+- `variant="outlined"`, `color="info"` で ResetButton と同じ雰囲気にする
+- ボタンテキストは `t("lore.backToGame")` で i18n 対応
+
+### 4. 設定資料集への遷移ボタン (`HomePage.tsx`)
+
+- `ResetButton` コンポーネントの直後 (閉じタグの下) に、固定位置の遷移ボタンを追加する
+- ResetButton が `position: fixed`, `bottom: 16`, `right: 16` なので、その下に配置する
+- 配置: `position: "fixed"`, `bottom: 16`, `right: 100` くらい (ResetButton の左隣)
+    - ...と思ったけど、ResetButton の Box は `display: flex`, `gap: 2` なので、ResetButton コンポーネント内に並べるのがスマート！
+- 方針変更: `ResetButton.tsx` に設定資料集ボタンを追加する
+
+変更後の `ResetButton.tsx`:
+
+```tsx
+import { Button, Box } from "@mui/material";
+import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+
+type Props = {
+  onClick: () => void;
+};
+
+const ResetButton = ({ onClick }: Props) => {
+  const { t } = useTranslation();
+  return (
+    <Box
+      sx={{
+        position: "fixed",
+        bottom: 16,
+        right: 16,
+        display: "flex",
+        gap: 2,
+        zIndex: (theme) => theme.zIndex.tooltip + 1,
+      }}
+    >
+      <Button
+        variant="outlined"
+        component={Link}
+        to="/lore"
+        color="info"
+      >
+        {t("lore.title")}
+      </Button>
+      <Button variant="outlined" onClick={onClick} color="info">
+        Reset
+      </Button>
+    </Box>
+  );
+};
+```
+
+- 設定資料集ボタンは Reset ボタンの左側に表示される (flex + gap で自然に並ぶ)
+- `component={Link}` と `to="/lore"` で React Router のリンクとして動作する
+
+### 5. 翻訳ファイルの更新
+
+`locales/ja/translation.json` に追加:
+
+```json
+{
+  "lore.title": "設定資料集",
+  "lore.subtitle": "ばななちゃんのひみつ、教えちゃうよ！",
+  "lore.backToGame": "ゲームに戻る",
+  "lore.bgm.question": "このゲームにはどんな曲がある？",
+  "lore.bgm.answer": "2 曲あるよ！「ばななちゃんのテーマ」と「ばななちゃんのテーマ - ピアノ」の 2 曲。通常のシーンではテーマ曲が流れて、エンディングではピアノ版が流れるんだ。"
+}
+```
+
+`locales/en/translation.json` に追加:
+
+```json
+{
+  "lore.title": "Lore",
+  "lore.subtitle": "Let me tell you Banana-chan's secrets!",
+  "lore.backToGame": "Back to Game",
+  "lore.bgm.question": "What kind of music does this game have?",
+  "lore.bgm.answer": "There are 2 tracks! \"Banana-chan's Theme\" and \"Banana-chan's Theme - Piano\". The theme song plays during normal scenes, and the piano version plays during the ending."
+}
+```
+
+### 6. 変更ファイルまとめ
+
+| ファイル | 変更内容 |
+|---|---|
+| `src/App.tsx` | `/lore` ルート追加、LorePage の import |
+| `src/pages/LorePage.tsx` | 新規作成。QA 形式の設定資料集ページ |
+| `src/components/ResetButton.tsx` | 設定資料集への遷移ボタン追加 |
+| `src/locales/ja/translation.json` | lore 関連の翻訳キー追加 |
+| `src/locales/en/translation.json` | lore 関連の翻訳キー追加 |

--- a/docs/agent/037-設定資料集ページ追加.md
+++ b/docs/agent/037-設定資料集ページ追加.md
@@ -1,0 +1,24 @@
+# 037 - 設定資料集ページ追加
+
+## 要望
+
+- ゲームの「設定資料集」ページを新しく作る
+- メインゲーム画面 (`/`) とは別の URL に配置する
+- メインゲーム画面の RESET ボタンの下に、設定資料集への遷移ボタンを追加する
+- メインゲーム画面と同じトンマナ (ボタンの色、カードの角丸など) で QA 風のページにする
+- QA の内容例:
+    - "このゲームにはどんな曲がある？" -> "2 曲あるよ。「ばななちゃんのテーマ」と「ばななちゃんのテーマ - ピアノ」。通常シーンではテーマ曲が、エンディングではピアノ版が流れるよ"
+
+## 現状
+
+- ルーティングは `App.tsx` で `react-router-dom` を使用。現在 `/` (HomePage) と `*` (NotFoundPage) のみ
+- ResetButton は `components/ResetButton.tsx` で `position: fixed`, `bottom: 16px`, `right: 16px` に配置
+- テーマカラー: primary `#fdd835` (バナナ色)、secondary `#8d6e63` (茶色)、info `#1e88e5` (青)
+- カード角丸: 14px (選択肢カード) / 18px (メイン Paper)
+- BGM_TRACKS 定数 (`useBgmPlayer.ts`):
+    - main: `banana-theme-64.mp3` (ばななちゃんのテーマ)
+    - ending: `banana-theme-piano-64.mp3` (ばななちゃんのテーマ - ピアノ)
+
+## 詳細設計
+
+(プランナーが記入する)

--- a/webapp/frontend-react/src/App.tsx
+++ b/webapp/frontend-react/src/App.tsx
@@ -1,5 +1,6 @@
 import "@/App.css"
 import HomePage from "@/pages/HomePage"
+import LorePage from "@/pages/LorePage"
 import NotFoundPage from "@/pages/NotFoundPage"
 import { Route, Routes } from "react-router-dom"
 
@@ -7,6 +8,7 @@ function App() {
   return (
     <Routes>
       <Route path="/" element={<HomePage />} />
+      <Route path="/lore" element={<LorePage />} />
       {/* その他のパスは 404 */}
       <Route path="*" element={<NotFoundPage />} />
     </Routes>

--- a/webapp/frontend-react/src/components/ResetButton.tsx
+++ b/webapp/frontend-react/src/components/ResetButton.tsx
@@ -1,10 +1,13 @@
 import { Button, Box } from "@mui/material";
+import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 
 type Props = {
   onClick: () => void;
 };
 
 const ResetButton = ({ onClick }: Props) => {
+  const { t } = useTranslation();
   return (
     <Box
       sx={{
@@ -17,6 +20,9 @@ const ResetButton = ({ onClick }: Props) => {
         zIndex: (theme) => theme.zIndex.tooltip + 1,
       }}
     >
+      <Button variant="outlined" component={Link} to="/lore" color="info">
+        {t("lore.title")}
+      </Button>
       {/* color は main.tsx の theme から。 */}
       <Button variant="outlined" onClick={onClick} color="info">
         Reset

--- a/webapp/frontend-react/src/i18n/index.ts
+++ b/webapp/frontend-react/src/i18n/index.ts
@@ -17,7 +17,7 @@ i18n
   .use(initReactI18next)
   .init({
     resources,
-    lng: 'en',
+    lng: 'ja',
     interpolation: {
       escapeValue: false
     }

--- a/webapp/frontend-react/src/locales/en/translation.json
+++ b/webapp/frontend-react/src/locales/en/translation.json
@@ -1,5 +1,10 @@
 {
   "Button がクリックされた!": "Button がクリックされた!",
   "Welcome to the Home Page": "Welcome to the Home Page",
-  "Click Me": "Click Me"
+  "Click Me": "Click Me",
+  "lore.title": "Lore",
+  "lore.subtitle": "Let me tell you Banana-chan's secrets!",
+  "lore.backToGame": "Back to Game",
+  "lore.bgm.question": "What kind of music does this game have?",
+  "lore.bgm.answer": "There are 2 tracks! \"Banana-chan's Theme\" and \"Banana-chan's Theme - Piano\". The theme song plays during normal scenes, and the piano version plays during the ending."
 }

--- a/webapp/frontend-react/src/locales/ja/translation.json
+++ b/webapp/frontend-react/src/locales/ja/translation.json
@@ -1,5 +1,10 @@
 {
   "Button がクリックされた!": "Button がクリックされた!",
   "Welcome to the Home Page": "Welcome to the Home Page",
-  "Click Me": "Click Me"
+  "Click Me": "Click Me",
+  "lore.title": "設定資料集",
+  "lore.subtitle": "ばななちゃんのひみつ、教えちゃうよ！",
+  "lore.backToGame": "ゲームに戻る",
+  "lore.bgm.question": "このゲームにはどんな曲がある？",
+  "lore.bgm.answer": "2 曲あるよ！「ばななちゃんのテーマ」と「ばななちゃんのテーマ - ピアノ」の 2 曲。通常のシーンではテーマ曲が流れて、エンディングではピアノ版が流れるんだ。"
 }

--- a/webapp/frontend-react/src/pages/LorePage.tsx
+++ b/webapp/frontend-react/src/pages/LorePage.tsx
@@ -1,0 +1,65 @@
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Button,
+  Typography,
+} from "@mui/material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+
+const loreItems = [
+  {
+    questionKey: "lore.bgm.question",
+    answerKey: "lore.bgm.answer",
+  },
+];
+
+const LorePage = () => {
+  const { t } = useTranslation();
+
+  return (
+    <Box sx={{ maxWidth: 960, mx: "auto", py: 4, px: { xs: 2, sm: 3 } }}>
+      <Typography variant="h4">{t("lore.title")}</Typography>
+      <Typography variant="body2" color="text.secondary">
+        {t("lore.subtitle")}
+      </Typography>
+
+      <Box sx={{ mt: 3 }}>
+        {loreItems.map((item, index) => (
+          <Accordion
+            key={index}
+            disableGutters
+            elevation={0}
+            sx={{
+              borderRadius: "14px !important",
+              overflow: "hidden",
+              mb: 1.5,
+              "&:before": { display: "none" },
+            }}
+          >
+            <AccordionSummary
+              expandIcon={<ExpandMoreIcon />}
+              sx={{ bgcolor: "primary.main" }}
+            >
+              <Typography>{t(item.questionKey)}</Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+              <Typography>{t(item.answerKey)}</Typography>
+            </AccordionDetails>
+          </Accordion>
+        ))}
+      </Box>
+
+      <Box sx={{ mt: 4, textAlign: "center" }}>
+        <Button variant="outlined" color="info" component={Link} to="/">
+          {t("lore.backToGame")}
+        </Button>
+      </Box>
+    </Box>
+  );
+};
+
+export default LorePage;


### PR DESCRIPTION
## 要望

- ゲームの「設定資料集」ページを `/lore` に新規作成
- メインゲーム画面の RESET ボタンの隣に、設定資料集への遷移ボタンを追加
- メインゲーム画面と同じトンマナで QA 風のページにする
- QA 例: "このゲームにはどんな曲がある？" -> 2 曲の紹介と使用シーンの説明
- デフォルト言語を日本語に変更

## 変更内容

- `LorePage.tsx` 新規作成: MUI Accordion で QA 形式の設定資料集ページ (バナナ色アクセント、角丸 14px)
- `App.tsx`: `/lore` ルート追加
- `ResetButton.tsx`: 設定資料集への遷移ボタンを RESET ボタンの左隣に追加
- `locales/ja/translation.json`, `locales/en/translation.json`: lore 関連の翻訳キー追加
- `i18n/index.ts`: デフォルト言語を `en` -> `ja` に変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)